### PR TITLE
Add date validation with typo suggestions

### DIFF
--- a/create.py
+++ b/create.py
@@ -68,14 +68,47 @@ def generate_month_rows(year: int, month: int) -> List[List[Any]]:
     return rows
 
 
-if __name__ == "__main__":
-    args = _parse_args()
-    year = args.year
-    month = args.month
+def _validate_date(year: int, month: int) -> None:
+    """Validate year and month are within reasonable range (last 3 months to next 3 months)."""
     if year < 1:
         raise SystemExit("Year must be positive")
     if not (1 <= month <= 12):
         raise SystemExit("Month must be between 1 and 12")
+    
+    today = dt.date.today()
+    current_year = today.year
+    current_month = today.month
+    
+    try:
+        input_date = dt.date(year, month, 1)
+    except ValueError:
+        raise SystemExit(f"Invalid date: {year}-{month:02d}")
+    
+    three_months_ago = today - dt.timedelta(days=90)
+    three_months_later = today + dt.timedelta(days=90)
+    
+    if input_date < three_months_ago or input_date > three_months_later:
+        suggestion = ""
+        if year > current_year + 100:
+            suggested_year = year - 1000
+            if 1900 <= suggested_year <= current_year + 10:
+                suggestion = f"\nDid you mean {suggested_year} instead of {year}?"
+        
+        error_msg = (
+            f"Date {year}-{month:02d} is outside the valid range.\n"
+            f"Please use dates between {three_months_ago.strftime('%Y-%m')} "
+            f"and {three_months_later.strftime('%Y-%m')} "
+            f"(last 3 months to next 3 months).{suggestion}"
+        )
+        raise SystemExit(error_msg)
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    year = args.year
+    month = args.month
+    
+    _validate_date(year, month)
 
     filename = f"{year}{month:02d}.xls"
 


### PR DESCRIPTION
# Add date validation with typo suggestions

## Summary
This PR implements date validation to address issue #2. The script now validates that the requested year/month falls within a reasonable range (last 3 months to next 3 months from today) and provides helpful suggestions for common typos like entering "3025" instead of "2025".

**Changes:**
- Added `_validate_date()` function that checks if the input date is within ±3 months from today
- Implemented typo detection for years that are 1000+ years in the future (e.g., 3025 → suggests 2025)
- Improved error messages to show the valid date range and suggestions

**Example behavior:**
```bash
$ python create.py 3025 11
Date 3025-11 is outside the valid range.
Please use dates between 2025-08 and 2026-02 (last 3 months to next 3 months).
Did you mean 2025 instead of 3025?
```

## Review & Testing Checklist for Human
- [ ] **Test boundary dates**: Verify that dates exactly 3 months ago and 3 months from now are handled correctly. The implementation uses a 90-day approximation which may not align perfectly with calendar months.
- [ ] **Verify breaking change impact**: This validation will reject dates outside the 3-month window that were previously accepted. Confirm this restriction aligns with your intended use case.
- [ ] **Test typo detection**: The typo suggestion currently only detects years >100 years in the future and suggests subtracting 1000. Test with "3025 11" to verify it suggests "2025", and consider if other common typos should be detected.
- [ ] **Test edge cases**: Try invalid months (0, 13), negative years, and dates near month boundaries to ensure error messages are clear.

**Suggested test plan:**
1. Test with current month: `python create.py 2025 11` (should work)
2. Test with typo: `python create.py 3025 11` (should suggest 2025)
3. Test with old date: `python create.py 2024 1` (should reject)
4. Test with future date within range: `python create.py 2026 1` (should work)
5. Test boundary dates around ±90 days from today

### Notes
- The 3-month range is calculated as ±90 days from today, which is an approximation and may not align exactly with calendar months
- This is a breaking change that will affect any existing workflows generating reports for dates outside the 3-month window
- No automated tests were added; consider adding unit tests for the validation logic

---
This PR was created with assistance from Devin. [Link to Devin run](https://app.devin.ai/sessions/e201e2aab746491694dfb6c940600b32)

Requested by: wangzz2009@outlook.com (@wangzz2019)