### PR TITLE
Add date range validation and typo suggestions

### DIFF
--- a/create.py
+++ b/create.py
@@ -1,6 +1,6 @@
 import argparse
 import xlwt
-from typing import List, Any
+from typing import List, Any, Optional, Tuple
 import calendar
 import datetime as dt
 import random
@@ -68,6 +68,74 @@ def generate_month_rows(year: int, month: int) -> List[List[Any]]:
     return rows
 
 
+def _get_allowed_date_range(months_offset: int = 3) -> Tuple[dt.date, dt.date]:
+    """
+    Calculate the allowed date range based on current date.
+    Returns (min_date, max_date) tuple.
+    """
+    today = dt.date.today()
+    
+    min_year = today.year
+    min_month = today.month - months_offset
+    while min_month < 1:
+        min_month += 12
+        min_year -= 1
+    min_date = dt.date(min_year, min_month, 1)
+    
+    max_year = today.year
+    max_month = today.month + months_offset
+    while max_month > 12:
+        max_month -= 12
+        max_year += 1
+    last_day = calendar.monthrange(max_year, max_month)[1]
+    max_date = dt.date(max_year, max_month, last_day)
+    
+    return min_date, max_date
+
+
+def _suggest_year_correction(year: int) -> Optional[int]:
+    """
+    Suggest a corrected year if the input appears to be a typo.
+    Common typo: first digit wrong (e.g., 3025 -> 2025)
+    """
+    current_year = dt.date.today().year
+    year_str = str(year)
+    
+    if len(year_str) == 4:
+        for first_digit in ['1', '2', '3']:
+            suggested = int(first_digit + year_str[1:])
+            if 1900 <= suggested <= 2100 and abs(suggested - current_year) <= 10:
+                return suggested
+    
+    return None
+
+
+def _validate_date_range(year: int, month: int) -> None:
+    """
+    Validate that the requested year/month is within allowed range.
+    Raises SystemExit with helpful message if validation fails.
+    """
+    min_date, max_date = _get_allowed_date_range()
+    
+    try:
+        requested_date = dt.date(year, month, 1)
+    except ValueError:
+        raise SystemExit(f"Invalid date: year={year}, month={month}")
+    
+    if requested_date < min_date or requested_date > max_date:
+        error_msg = (
+            f"Date {year}/{month:02d} is outside the allowed range.\n"
+            f"Allowed range: {min_date.strftime('%Y/%m')} to {max_date.strftime('%Y/%m')} "
+            f"(±3 months from today)"
+        )
+        
+        suggested_year = _suggest_year_correction(year)
+        if suggested_year and suggested_year != year:
+            error_msg += f"\n\nDid you mean {suggested_year} instead of {year}?"
+        
+        raise SystemExit(error_msg)
+
+
 if __name__ == "__main__":
     args = _parse_args()
     year = args.year
@@ -76,6 +144,8 @@ if __name__ == "__main__":
         raise SystemExit("Year must be positive")
     if not (1 <= month <= 12):
         raise SystemExit("Month must be between 1 and 12")
+    
+    _validate_date_range(year, month)
 
     filename = f"{year}{month:02d}.xls"
 


### PR DESCRIPTION
# Add date range validation and typo suggestions

## Summary
This PR addresses issue #2 by adding validation to prevent unrealistic year inputs and suggesting corrections for common typos.

**Changes:**
- Added `_validate_date_range()` function that restricts input to ±3 months from the current date
- Added `_suggest_year_correction()` function that detects common year typos (e.g., 3025 → 2025) by checking if the first digit appears wrong
- Integrated validation into the main execution flow after basic year/month checks
- Enhanced error messages to show the allowed date range and suggest corrections when applicable

**Example behavior:**
```bash
$ python create.py 3025 11
Date 3025/11 is outside the allowed range.
Allowed range: 2025/08 to 2026/02 (±3 months from today)

Did you mean 2025 instead of 3025?
```

## Review & Testing Checklist for Human
- [ ] **Test date range calculation around year boundaries** - Run the script in different months (especially January/December) to verify the ±3 month calculation correctly handles year rollovers
- [ ] **Verify typo suggestion logic** - Test with various typo patterns (e.g., 1025, 2024, 3025, 4025) to ensure suggestions are appropriate and don't appear when they shouldn't
- [ ] **Test boundary dates** - Try dates exactly at the min/max boundaries of the allowed range to ensure they're accepted
- [ ] **Confirm error messages are clear** - Review the error output for dates outside the range to ensure it's helpful for users
- [ ] **Verify existing functionality** - Test with valid dates within the allowed range to ensure report generation still works correctly

**Suggested test plan:**
1. Test with current month ±1, ±2, ±3 months (should all pass)
2. Test with current month ±4 months (should fail with clear error)
3. Test with obvious typos like 3025, 1025 (should suggest corrections)
4. Test with dates outside range but no obvious typo like 2020 (should fail without suggestion)

### Notes
- The ±3 months range is hardcoded as specified in the issue requirements
- The typo detection focuses on first-digit errors, which is the most common typo pattern mentioned in the issue
- No new dependencies were added; all functionality uses Python standard library

---
**Link to Devin run:** https://app.devin.ai/sessions/2f8c5dc4c83f4d09a6a561fe8c0f6544  
**Requested by:** wangzz2009@outlook.com (@wangzz2019)