### PR TITLE
Change date validation from ±4 months to ±5 months

### DIFF
--- a/create.py
+++ b/create.py
@@ -68,7 +68,7 @@ def generate_month_rows(year: int, month: int) -> List[List[Any]]:
     return rows
 
 
-def _get_allowed_date_range(months_offset: int = 4) -> Tuple[dt.date, dt.date]:
+def _get_allowed_date_range(months_offset: int = 5) -> Tuple[dt.date, dt.date]:
     """
     Calculate the allowed date range based on current date.
     Returns (min_date, max_date) tuple.
@@ -126,7 +126,7 @@ def _validate_date_range(year: int, month: int) -> None:
         error_msg = (
             f"Date {year}/{month:02d} is outside the allowed range.\n"
             f"Allowed range: {min_date.strftime('%Y/%m')} to {max_date.strftime('%Y/%m')} "
-            f"(±4 months from today)"
+            f"(±5 months from today)"
         )
         
         suggested_year = _suggest_year_correction(year)


### PR DESCRIPTION
# Change date validation from ±4 months to ±5 months

## Summary
Updated the date validation logic to allow report generation for dates within ±5 months from today, expanding from the previous ±4 month range. This change addresses issue #7.

**Changes:**
- Updated `_get_allowed_date_range()` default parameter from `months_offset=4` to `months_offset=5`
- Updated error message to reflect the new "±5 months from today" range

## Review & Testing Checklist for Human
- [ ] Test with a date exactly 5 months in the future (should be accepted)
- [ ] Test with a date exactly 5 months in the past (should be accepted)
- [ ] Test with a date 6 months away (should be rejected with correct error message)
- [ ] Verify the error message displays "±5 months from today" when validation fails

### Test Plan
```bash
# Get today's date and calculate test dates
# Example: If today is 2025-11-18
python create.py 2026 4   # Should work (5 months ahead)
python create.py 2025 6   # Should work (5 months back)
python create.py 2026 5   # Should fail (6 months ahead)
python create.py 2025 5   # Should fail (6 months back)
```

### Notes
- This is a straightforward parameter change with no logic modifications
- Both the function parameter and error message were updated for consistency
- Resolves issue #7

**Link to Devin run:** https://app.devin.ai/sessions/9e84e871681f4b99a3807c57c2a66104  
**Requested by:** wangzz2009@outlook.com (@wangzz2019)